### PR TITLE
Building baton on top of irods-legacy for packaging/testing/CI purposes, should fix issue #59

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq odbc-postgresql unixodbc-dev
+- sudo apt-get install -qq odbc-postgresql unixodbc-dev git libjansson-dev libjansson4
 
 language: c
 
@@ -23,9 +23,11 @@ script:
   - cd $TRAVIS_BUILD_DIR
 
 after_script:
-  - sudo -E -u postgres $TRAVIS_BUILD_DIR/setup_pgusers.sh
-  - sudo -E -u postgres $TRAVIS_BUILD_DIR/irodscontrol psetup
-  - $TRAVIS_BUILD_DIR/smoke_test.sh
+#  - sudo -E -u postgres $TRAVIS_BUILD_DIR/setup_pgusers.sh
+#  - sudo -E -u postgres $TRAVIS_BUILD_DIR/irodscontrol psetup
+  - git clone https://github.com/wtsi-npg/baton.git baton && cd baton
+  - ../build_baton_release.sh
+#  - $TRAVIS_BUILD_DIR/smoke_test.sh
 
 after_failure:
   - cat $IRODS_HOME/server/log/rodsLog.*
@@ -45,3 +47,6 @@ deploy:
 branches:
   only:
   - travis-build
+
+notifications:
+    email: false

--- a/build_baton_release.sh
+++ b/build_baton_release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Build baton against irods-legacy libraries
+
+set -e
+
+# Already set by .travis.yml...
+IRODS_HOME=$IRODS_HOME source ./scripts/set_irods_home.sh
+echo "iRODS \$HOME is currently set to: $IRODS_HOME"
+
+# Generate the configure script
+autoreconf -i
+
+# Generate the makefiles (see INSTALL for arguments to configure)
+./configure
+
+# Compile
+make
+
+# Install, including HTML manual and manpage.
+make clean install
+
+./baton


### PR DESCRIPTION
@keithj, I've encountered some obvious breakage while building baton at Travis, I guess that's because of some divergence with master branch?:

https://travis-ci.org/brainstorm/irods-legacy#L818

```
json_query.c: In function ‘add_tps_json_object’:
json_query.c:525:9: error: implicit declaration of function ‘json_array_foreach’ [-Werror=implicit-function-declaration]
json_query.c:525:63: error: expected ‘;’ before ‘{’ token
```
